### PR TITLE
[11] Update readme to contain installation and development instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ EXE_NAME_SERVER_ROUTE_TEST_CLIENT := rogue_forever_server_route_test_client
 EXE_NAME_TEST := rogue_forever_test
 WINDOWS_DEPLOY_DST := /mnt/d/rogue_forever_deploy
 WINDOWS_DEPLOY_SRC := \
-			$(WINDOWS_EXE_NAME_GAME)
+			$(WINDOWS_EXE_NAME_GAME) \
+			scripts/install_runtime_dependencies_release.ps1
 
 ALL_EXE_NAMES := \
 		 $(EXE_NAME_GAME) \

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,7 @@ EXE_NAME_SERVER_ROUTE_TEST_CLIENT := rogue_forever_server_route_test_client
 EXE_NAME_TEST := rogue_forever_test
 WINDOWS_DEPLOY_DST := /mnt/d/rogue_forever_deploy
 WINDOWS_DEPLOY_SRC := \
-			./assets \
-			./maps \
-			$(WINDOWS_EXE_NAME_GAME) \
-			./SDL2.dll \
-			./SDL2_image.dll
+			$(WINDOWS_EXE_NAME_GAME)
 
 ALL_EXE_NAMES := \
 		 $(EXE_NAME_GAME) \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,129 @@
 # rogue_forever
 A dungeon crawler
 
+## How to install for playing the game
+
+In order to run the game a main executable is required in addition to some
+runtime dependencies, such as graphics assets and maps.
+
+Operating system specific installation instructions can be found below.
+
+### Installing on Linux variants
+Linux installation method is compiling the main executable from source and
+proceeding to retrieve runtime dependencies from the web, possibly
+utilizing a provided shell script. To install, you may walk through the
+following more detailed instructions.
+
+#### Installing on Debian Linux
+This instruction is written for a 0.0.0 test release. Please substitute 0.0.0
+with the version number of the release which you wish to install.
+
+Open a terminal program for running commands, such as `wget` command.
+
+First, update system packages.
+```
+sudo apt update && sudo apt upgrade && sudo apt autoremove
+```
+
+Change current directory to the directory where you want to store the files
+of the game.
+```
+cd ${HOME}/games # For example
+```
+
+Using a web browser, navigate to page:
+https://github.com/pottumuusi/rogue-forever/releases
+
+Right click and copy link of 'Source code (tar.gz)' of wanted release. Paste
+the link to `wget`.
+```
+wget -O rogue-forever-0.0.0.tar.gz https://github.com/pottumuusi/rogue-forever/archive/refs/tags/0.0.0.tar.gz
+```
+
+Extract the compressed file and change directory to the newly created directory.
+```
+tar xvf ./rogue-forever-0.0.0.tar.gz
+cd rogue-forever-0.0.0/
+```
+
+Install build dependencies, which make it possible to compile source code.
+This script takes a while. An estimate duration is under 10 minutes.
+```
+./scripts/install_build_dependencies/install_build_dependencies.sh linux | tee output_install_build_dependencies.txt
+```
+
+Retrieve runtime dependencies from the web.
+```
+./scripts/install_runtime_dependencies_release.sh | tee output_install_runtime_dependencies_release.txt
+```
+
+Optionally run the unit tests of project.
+```
+make test
+```
+
+Compile the main executable.
+```
+make linux
+```
+
+The game can then be started.
+```
+make linux_run
+```
+
+### Installing on Windows
+For Windows, an executable is provided along with a script for installing
+runtime dependencies from the web. To install, you may walk through the
+following instructions.
+
+Using a web browser, navigate to page:
+https://github.com/pottumuusi/rogue-forever/releases
+
+Download the Windows release zip to a directory you want to store the game in
+and extract the zip package.
+
+Open Powershell as administrator for running upcoming.
+
+Change current directory to the directory extracted from the zip.
+```
+cd "$env:USERPROFILE\games\rogue-forever-windows-0.0.0" # For example
+```
+
+Query for the current execution policy. The result is used for restoring the
+original execution policy when install is done.
+```
+Get-ExecutionPolicy
+```
+
+Allow running unsigned scripts.
+```
+Set-ExecutionPolicy --ExecutionPolicy Unrestricted
+```
+
+Retrieve runtime dependencies from the web by running .
+```
+.\install_runtime_dependencies_release.ps1
+```
+The command should produce a warning. To download the dependencies, please
+consult the warning message for allowing running the script.
+
+To restore execution policy, please run
+```
+Set-ExecutionPolicy --ExecutionPolicy <original_policy>
+```
+replacing '<original_policy>' with the policy which was queried earlier in the
+instructions. You can alternatively use
+```
+Set-ExecutionPolicy --ExecutionPolicy Default
+```
+in case you have been using default execution policy.
+
+The game can now be started by running executable `rogue_forever.exe`.
+
+## How to install for developing the game
+TODO write the instructions
+
 How to run
 ==========
 Linux

--- a/README.md
+++ b/README.md
@@ -222,6 +222,6 @@ is a script `scripts/install_runtime_dependencies_release.ps1` for installing
 the runtime dependencies for Windows. To move the built executable and mentioned
 script from WSL to a directory of hosting Windows, you can use `make` target
 `windows_deploy`. Before running `make` with `windows_deploy` target, please
-modify the deploy destination path in Makefile to suit your needs. See Windows
+modify the deploy destination path in `Makefile` to suit your needs. See Windows
 install instructions for an example on how to utilize the runtime dependencies
 install script.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # rogue_forever
-A dungeon crawler
+A dungeon crawler game.
+
+Game currently consists of drawing a static image from a map representation file
+and a spritesheet. On top of this image, a player character placeholder is drawn
+to the coordinate 0, 0 in left upper corner. The map representation file and
+spritesheet were created using Tiled map editor.
+
+Tiled home page:
+https://www.mapeditor.org/
 
 ## How to install for playing the game
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rogue_forever
+# Rogue Forever
 A dungeon crawler game.
 
 Game currently consists of drawing a static image from a map representation file

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ runtime dependencies, such as graphics assets and maps.
 
 Operating system specific installation instructions can be found below.
 
+* [Instaling on Debian Linux](#installing-on-debian-linux)
+* [Installing on Windows](#installing-on-windows)
+
 ### Installing on Linux variants
 Linux installation method is compiling the main executable from source and
 proceeding to retrieve runtime dependencies from the web, possibly

--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ make linux_run
 ```
 
 ### Developing for Windows
+A straightforward way for Windows development is to utilize Windows Subsystem
+for Linux (WSL). In WSL, perform the development environment setup as instructed
+next.
+
 Clone the repository.
 ```
 sudo apt update && sudo apt upgrade && sudo apt autoremove
@@ -215,12 +219,9 @@ make windows
 For testing your changes, the game executable `rogue_forever.exe` can then be
 started on a Windows host, where runtime dependencies have been installed. There
 is a script `scripts/install_runtime_dependencies_release.ps1` for installing
-the runtime dependencies for Windows. This script is packaged to the release zip
-of Windows.  See Windows install instructions for an example on how to utilize
-the script.
-
-A straightforward way for Windows development is to utilize Windows Subsystem
-for Linux (WSL). In WSL, perform the above development environment setup. Then
-to test the changes made to game, you can use `make` target `windows_deploy`.
-Before running `make` with `windows_deploy` target, please modify the deploy
-destination path in Makefile to suit your needs.
+the runtime dependencies for Windows. To move the built executable and mentioned
+script from WSL to a directory of hosting Windows, you can use `make` target
+`windows_deploy`. Before running `make` with `windows_deploy` target, please
+modify the deploy destination path in Makefile to suit your needs. See Windows
+install instructions for an example on how to utilize the runtime dependencies
+install script.

--- a/README.md
+++ b/README.md
@@ -200,3 +200,9 @@ where runtime dependencies have been installed. There is a script
 `scripts/install_runtime_dependencies_release.ps1` for installing the runtime
 dependencies for Windows. This script is packaged to the release zip of Windows.
 See Windows install instructions for an example on how to utilize the script.
+
+A straightforward way for Windows development is to utilize Windows Subsystem
+for Linux (WSL). In WSL, perform the above development environment setup. Then
+to test the changes made to game, you can use `make` target `windows_deploy`.
+Before running `make` with `windows_deploy` target, please modify the deploy
+destination path in Makefile to suit your needs.

--- a/README.md
+++ b/README.md
@@ -123,31 +123,3 @@ The game can now be started by running executable `rogue_forever.exe`.
 
 ## How to install for developing the game
 TODO write the instructions
-
-How to run
-==========
-Linux
------
-```
-./create_meson_build_dir.sh
-cd build && PATH="${PATH}:${HOME}.local/bin" meson compile && cd ..
-./run_rogue_forever.sh
-```
-
-Windows
--------
-```
-create_meson_build_dir.bat
-cd build
-meson compile
-cd ..
-run_rogue_forever.bat
-```
-
-How to get required assets
-==========================
-Ask the owner of the repo for the assets. In the future asset getting is to be
-done automatically by client on startup.<br/>
-See progress from:
-* https://github.com/arbiter0xf/rogue_forever/issues/18
-* https://github.com/arbiter0xf/rogue_forever/tree/initial_asset_server

--- a/README.md
+++ b/README.md
@@ -122,4 +122,81 @@ in case you have been using default execution policy.
 The game can now be started by running executable `rogue_forever.exe`.
 
 ## How to install for developing the game
-TODO write the instructions
+For developing the game, you can fork this repository and develop your copy
+further. The following instructions are written against the original
+repository.
+
+### Developing for Linux
+Clone the repository.
+```
+sudo apt update && sudo apt upgrade && sudo apt autoremove
+```
+```
+sudo apt install git
+```
+```
+git clone git@github.com:pottumuusi/rogue-forever.git
+```
+
+In the project base directory, install build dependencies.
+```
+./scripts/install_build_dependencies/install_build_dependencies.sh linux | tee output_install_build_dependencies.txt
+```
+
+Install runtime dependencies.
+```
+./scripts/install_runtime_dependencies_development.sh | tee output_install_runtime_dependencies_development.txt
+```
+
+Run the unit tests of project.
+```
+make test
+```
+
+Compile the main executable.
+```
+make linux
+```
+
+The game can then be started.
+```
+make linux_run
+```
+
+### Developing for Windows
+Clone the repository.
+```
+sudo apt update && sudo apt upgrade && sudo apt autoremove
+```
+```
+sudo apt install git
+```
+```
+git clone git@github.com:pottumuusi/rogue-forever.git
+```
+
+In the project base directory, install build dependencies.
+```
+./scripts/install_build_dependencies/install_build_dependencies.sh full | tee output_install_build_dependencies.txt
+```
+
+Install runtime dependencies.
+```
+./scripts/install_runtime_dependencies_development.sh | tee output_install_runtime_dependencies_development.txt
+```
+
+Run the unit tests of project.
+```
+make test
+```
+
+Compile the main executable.
+```
+make windows
+```
+
+The game executable `rogue_forever.exe` can then be started on a Windows host,
+where runtime dependencies have been installed. There is a script
+`scripts/install_runtime_dependencies_release.ps1` for installing the runtime
+dependencies for Windows. This script is packaged to the release zip of Windows.
+See Windows install instructions for an example on how to utilize the script.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Open Powershell as administrator for running upcoming.
 
 Change current directory to the directory extracted from the zip.
 ```
-cd "$env:USERPROFILE\games\rogue-forever-windows-0.0.0" # For example
+cd "C:\Users\johndoe\games\rogue-forever-windows-0.0.0" # For example
 ```
 
 Query for the current execution policy. The result is used for restoring the

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ following instructions.
 Using a web browser, navigate to page:
 https://github.com/pottumuusi/rogue-forever/releases
 
-Download the Windows release zip to a directory you want to store the game in
+Download a Windows release zip to a directory where you want to store the game
 and extract the zip package.
 
-Open Powershell as administrator for running upcoming.
+Open Powershell as administrator for running upcoming commands.
 
 Change current directory to the directory extracted from the zip.
 ```
@@ -112,7 +112,7 @@ Allow running unsigned scripts.
 Set-ExecutionPolicy --ExecutionPolicy Unrestricted
 ```
 
-Retrieve runtime dependencies from the web by running .
+Retrieve runtime dependencies from the web by running script from release zip.
 ```
 .\install_runtime_dependencies_release.ps1
 ```
@@ -143,6 +143,9 @@ Clone the repository.
 sudo apt update && sudo apt upgrade && sudo apt autoremove
 ```
 ```
+ssh-keygen -t ed25519 # In case you have yet to generate SSH keypair
+```
+```
 sudo apt install git
 ```
 ```
@@ -169,7 +172,7 @@ Compile the main executable.
 make linux
 ```
 
-The game can then be started.
+The game can then be started for testing your changes.
 ```
 make linux_run
 ```
@@ -178,6 +181,9 @@ make linux_run
 Clone the repository.
 ```
 sudo apt update && sudo apt upgrade && sudo apt autoremove
+```
+```
+ssh-keygen -t ed25519 # In case you have yet to generate SSH keypair
 ```
 ```
 sudo apt install git
@@ -206,11 +212,12 @@ Compile the main executable.
 make windows
 ```
 
-The game executable `rogue_forever.exe` can then be started on a Windows host,
-where runtime dependencies have been installed. There is a script
-`scripts/install_runtime_dependencies_release.ps1` for installing the runtime
-dependencies for Windows. This script is packaged to the release zip of Windows.
-See Windows install instructions for an example on how to utilize the script.
+For testing your changes, the game executable `rogue_forever.exe` can then be
+started on a Windows host, where runtime dependencies have been installed. There
+is a script `scripts/install_runtime_dependencies_release.ps1` for installing
+the runtime dependencies for Windows. This script is packaged to the release zip
+of Windows.  See Windows install instructions for an example on how to utilize
+the script.
 
 A straightforward way for Windows development is to utilize Windows Subsystem
 for Linux (WSL). In WSL, perform the above development environment setup. Then

--- a/scripts/install_runtime_dependencies_development.sh
+++ b/scripts/install_runtime_dependencies_development.sh
@@ -4,7 +4,6 @@ set -e
 
 readonly INSTALL_ASSETS="TRUE"
 readonly INSTALL_MAPS="TRUE"
-readonly INSTALL_SDL2_WINDOWS_DLL="TRUE"
 
 cd $(dirname $0)
 
@@ -27,16 +26,6 @@ main() {
         wget http://gitlab.justworks.today/rogue-forever/maps_basic.zip
         unzip maps_basic.zip
         mv --verbose ./maps ${rogue_forever_base_path}/
-    fi
-
-    if [ "TRUE" == "${INSTALL_SDL2_WINDOWS_DLL}" ] ; then
-        echo "Installing SDL2 .dll files for Windows build"
-        wget https://github.com/libsdl-org/SDL/releases/download/release-2.30.6/SDL2-2.30.6-win32-x64.zip
-        wget https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.2/SDL2_image-2.8.2-win32-x64.zip
-        unzip SDL2-2.30.6-win32-x64.zip
-        unzip SDL2_image-2.8.2-win32-x64.zip
-        mv --verbose SDL2.dll ${rogue_forever_base_path}/
-        mv --verbose SDL2_image.dll ${rogue_forever_base_path}/
     fi
 
     popd # ${workarea_path}


### PR DESCRIPTION
Also:
* Remove SDL DLL downloading from development version of runtime dependency install script as the DLL files are not needed during development.
* Deploy executable and runtime dependency install script when running `windows_deploy` target.

Implement #11 